### PR TITLE
Specify width/height and gaplessPlayback on image to avoid layout change/flicker

### DIFF
--- a/ui/lib/spectrum.dart
+++ b/ui/lib/spectrum.dart
@@ -72,7 +72,8 @@ class _SpectrumState extends State<Spectrum> {
         Display.imageBuffer(memory), Image2.Image.RGBA);
 
     final jpg = Image2.encodeJpg(frame, quality: 100);
-    final img = new Image.memory(jpg);
+    final img = new Image.memory(jpg,
+        width: Display.Width.toDouble(), height: Display.Height.toDouble());
     displayFrame = img;
   }
 

--- a/ui/lib/spectrum.dart
+++ b/ui/lib/spectrum.dart
@@ -73,7 +73,9 @@ class _SpectrumState extends State<Spectrum> {
 
     final jpg = Image2.encodeJpg(frame, quality: 100);
     final img = new Image.memory(jpg,
-        width: Display.Width.toDouble(), height: Display.Height.toDouble());
+        width: Display.Width.toDouble(),
+        height: Display.Height.toDouble(),
+        gaplessPlayback: true);
     displayFrame = img;
   }
 


### PR DESCRIPTION
Without width/height, the layout visible changes and you see the "Program counter: xxx" text jump around. From the dartdoc on the `Image.memory` constructor:

> Either the `width` and `height` arguments should be specified, or the widget should be placed in a context that sets tight layout constraints.
> Otherwise, the image dimensions will change as the image is loaded, which will result in ugly layout changes.

With this first change, the layout change is gone, but the image still flickers because it seems to be processed asynchronously (I don't know why since it's memory bytes).

The second change sets `gaplessPlayback: true` which causes the previous frame to remain visible until the second one has "loaded", which eliminates the flicker entirely.